### PR TITLE
Add OAD reserved namespace.

### DIFF
--- a/guano_specification.md
+++ b/guano_specification.md
@@ -216,6 +216,9 @@ this list so that it isn't accidentally used by another manufacturer.
 **Anabat**  
   Titley Scientific
 
+**AM**  
+  Open Acoustic Devices
+
 **BAT**  
   Binary Acoustic Technologies
   

--- a/guano_specification.md
+++ b/guano_specification.md
@@ -216,9 +216,6 @@ this list so that it isn't accidentally used by another manufacturer.
 **Anabat**  
   Titley Scientific
 
-**AM**  
-  Open Acoustic Devices
-
 **BAT**  
   Binary Acoustic Technologies
   
@@ -231,6 +228,9 @@ this list so that it isn't accidentally used by another manufacturer.
 **NABat**  
   North American Bat Monitoring Program
 
+**OAD**  
+  Open Acoustic Devices
+  
 **PET**  
   Pettersson
 


### PR DESCRIPTION
On behalf of Open Acoustic Devices I would like to add the **AM** reserved namespace to the GUANO spec.